### PR TITLE
Updated ghs project generation to fix two issues:

### DIFF
--- a/templates/ghs.mpd
+++ b/templates/ghs.mpd
@@ -2,7 +2,7 @@
 #primaryTarget=<%primaryTarget("ppc_integrity.tgt")%>
 <%if(exename)%>
 [Program]
-	-o <%if(exeout)%><%exeout%><%endif%>/<%exename%><%if(use_exe_modifier)%><%lib_modifier%><%endif%><%exe_ext%>
+	-o <%if(exeout)%><%exeout%>/<%endif%><%exename%><%if(use_exe_modifier)%><%lib_modifier%><%endif%><%exe_ext%>
 <%if(need_staticflags)%>
 	-non_shared
 <%endif%>
@@ -135,6 +135,8 @@
 <%if(!custom_only && source_files)%>
 <%foreach(custom_type->input_file->source_output_files)%>
 <%if(forfirst)%>
+<%if(remove_from(source_files, \.cpp, custom_type->input_file->source_output_file, \.cpp))%>
+<%endif%>
 <%custom_type->input_file->source_output_file%>
 <%endif%>
 <%endfor%>


### PR DESCRIPTION
Generated source files could appear twice in the gpj, causing a linker error for multiply-defined symbols.

Projects that don't use exeout shouldn't have a / prepended (use local dir)